### PR TITLE
move the font styles import to .angular-cli.json

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -18,7 +18,10 @@
         "testTsconfig": "tsconfig.spec.json",
         "prefix": "app",
         "styles": [
-            "styles.less"
+            "styles.less",
+            "../node_modules/font-awesome/css/font-awesome.css",
+            "../node_modules/simple-line-icons/css/simple-line-icons.css",
+            "../node_modules/weather-icons/css/weather-icons.css"
         ],
         "scripts": [
             "../node_modules/@antv/g2/dist/g2.min.js",

--- a/src/styles.less
+++ b/src/styles.less
@@ -1,10 +1,5 @@
 /* You can add global styles to this file, and also import other style files */
 
-// web font icon
-@import '../node_modules/font-awesome/css/font-awesome.css';
-@import '../node_modules/simple-line-icons/css/simple-line-icons.css';
-@import '../node_modules/weather-icons/css/weather-icons.css';
-
 // ng-alain
 @import '~@delon/theme/styles/index';
 @import "./styles/_alain-custom-variables";


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/cipchk/ng-alain/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```
With angular 5, webpack can't locate font files correctly in styles.less. Follow Angular suggestions, move the css imports to .angular.json.


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #205 


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
