### PR TITLE
修复DefaultInterceptor中统一加上服务端前缀方法，以适应多域http数据源

### DIFF
--- a/src/app/core/net/default.interceptor.ts
+++ b/src/app/core/net/default.interceptor.ts
@@ -94,7 +94,11 @@ export class DefaultInterceptor implements HttpInterceptor {
     // 统一加上服务端前缀
     let url = req.url;
     if (!url.startsWith('https://') && !url.startsWith('http://')) {
-      url = environment.SERVER_URL + url;
+      if (url.startsWith('/') || url.startsWith('\\')) {
+        url = environment.SERVER_URL + url;
+      } else {
+        url = './' + url;
+      }
     }
 
     const newReq = req.clone({


### PR DESCRIPTION
修复使用DefaultInterceptor时。当http请求的既有静态（同alain项目）又有服务端（跨域），统一加上服务端前缀方法不能正常处理的bug。
处理后：
所有以斜杠开头的url，合并environment.SERVER_URL设置的前缀；
所有以http(s)://开头的绝对地址不处理。
其它url视为同域资源，合并'./'头

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/cipchk/ng-alain/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
