### PR TITLE
fix: isFetching status if using angular preloading

### DIFF
--- a/src/app/layout/default/default.component.ts
+++ b/src/app/layout/default/default.component.ts
@@ -11,7 +11,7 @@ import {
   Inject,
 } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
-import { Router, NavigationEnd, RouteConfigLoadStart, NavigationError, NavigationCancel } from '@angular/router';
+import { Router, NavigationEnd, RouteConfigLoadStart, RouteConfigLoadEnd, NavigationError, NavigationCancel } from '@angular/router';
 import { NzMessageService } from 'ng-zorro-antd';
 import { updateHostClass } from '@delon/util';
 import { SettingsService } from '@delon/theme';
@@ -52,12 +52,14 @@ export class LayoutDefaultComponent implements OnInit, AfterViewInit, OnDestroy 
         }
         return;
       }
-      if (!(evt instanceof NavigationEnd)) {
+      if (!(evt instanceof NavigationEnd || evt instanceof RouteConfigLoadEnd)) {
         return;
       }
-      setTimeout(() => {
-        this.isFetching = false;
-      }, 100);
+      if (this.isFetching) {
+        setTimeout(() => {
+          this.isFetching = false;
+        }, 100);
+      }
     });
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-alain/ng-alain/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
isFetching bar always showing when I add angular preloading strategy like as 1000ms delay to preload a module 
Issue Number: N/A


## What is the new behavior?
isFetching bar will not display after NavigationEnd and RouteConfigLoadEnd

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
