### PR TITLE
fix: 修复 NzModalRef 回调值丢失的问题

### DIFF
--- a/src/app/routes/extras/poi/edit/edit.component.ts
+++ b/src/app/routes/extras/poi/edit/edit.component.ts
@@ -22,8 +22,7 @@ export class ExtrasPoiEditComponent implements OnInit {
   save() {
     this.http.get('/pois').subscribe(() => {
       this.msgSrv.success('保存成功，只是模拟，实际未变更');
-      this.modal.close(true);
-      this.close();
+      this.modal.destroy(true);
     });
   }
 


### PR DESCRIPTION
NzModalRef，先 close(true) 再 destory()，会导致回调值丢失。 在 ng-zorro 8.x 版本中，不存在该问题

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ng-alain/ng-alain/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
