### PR TITLE
fix: correct missing `RouterLink` import

### DIFF
--- a/src/app/layout/basic/widgets/user.component.ts
+++ b/src/app/layout/basic/widgets/user.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { DA_SERVICE_TOKEN } from '@delon/auth';
 import { I18nPipe, SettingsService, User } from '@delon/theme';
 import { NzAvatarModule } from 'ng-zorro-antd/avatar';
@@ -38,7 +38,7 @@ import { NzMenuModule } from 'ng-zorro-antd/menu';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
-  imports: [NzDropDownModule, NzMenuModule, NzIconModule, I18nPipe, NzAvatarModule]
+  imports: [RouterLink, NzDropDownModule, NzMenuModule, NzIconModule, I18nPipe, NzAvatarModule]
 })
 export class HeaderUserComponent {
   private readonly settings = inject(SettingsService);


### PR DESCRIPTION
After the login is successful, the user icon drops menu in the upper right corner of the homepage, and the click is invalid
REPRODUCTION LINK
[https://github.com/ng-alain/ng-alain]

STEPS To Reproduce
After logging in, the drop -down menu of the user icon in the upper right corner of the homepage, click invalid

What is exfected?
Normal jump page

What is actually happy?
No response, no misunderstanding log

| ENVIRONMENT | Info |
| --- | --- | |
| NG-ALAIN | 17.2.0 |
| Browser | Version 121.0.6167.184 (official version) (ARM64) |